### PR TITLE
build(deps): resolve frontend dependency updates

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,7 +33,7 @@
         "tailwindcss": "^3.4.17",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.35.1",
-        "vite": "^7.1.5"
+        "vite": "^7.2.7"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,6 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.1.5"
+    "vite": "^7.2.7"
   }
 }


### PR DESCRIPTION
## Summary
- Supersedes stale Dependabot PR #25 on current `main`.
- Updates the frontend Vite devDependency range from `^7.1.5` to `^7.2.7`.
- Keeps the current lockfile resolutions already present on `main`: `vite` `7.3.2`, `glob` `10.5.0`, and `js-yaml` `4.1.1`.

## Verification
- `npm ci`
- `npm run type-check`
- `npm run lint` (passes with one existing React hook dependency warning)
- `npm test`
- `npm run build`
- `npm audit --audit-level=moderate`
