### PR TITLE
[codex] Add Dependabot hygiene config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    groups:
+      frontend-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    groups:
+      docker-images:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Add a minimal Dependabot configuration for the repo's existing dependency surfaces:

- GitHub Actions updates grouped weekly
- Go module updates grouped weekly
- frontend npm updates grouped weekly
- Docker image updates grouped weekly

The schedules are staggered during Central time business hours to keep automated update PRs readable and predictable.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`
- `git diff --check`
